### PR TITLE
better error message for unknown/unavailable/disallowed components

### DIFF
--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -13,6 +13,9 @@ export class Controller<ComponentConfig extends ComponentMapping = {}> {
   }
 
   get(type: string | RemoteComponentType<any, any, any>) {
+    if (!this.registry.has(type as any)) {
+      throw new Error(`Unknown component: ${type}`);
+    }
     return this.registry.get(type as any);
   }
 }


### PR DESCRIPTION
Before:
<img width="385" alt="Screen Shot 2020-04-09 at 3 16 09 PM" src="https://user-images.githubusercontent.com/132806/78936899-10cf3a00-7a75-11ea-894d-a39bdc7076ce.png">
Developer: "wait, what? what did I do wrong?" &lt;hours later/&gt; "Oh... I can't use that component here"

After:
<img width="327" alt="Screen Shot 2020-04-09 at 3 15 49 PM" src="https://user-images.githubusercontent.com/132806/78936912-175db180-7a75-11ea-8224-f7efad0d075e.png">
Developer: "Doh, MoneyLine isn't available here"