### PR TITLE
Remove iframe sandbox attribute

### DIFF
--- a/packages/web-workers/src/messenger/iframe.ts
+++ b/packages/web-workers/src/messenger/iframe.ts
@@ -25,7 +25,6 @@ export function createIframeWorkerMessenger(url: URL): MessageEndpoint {
   const {port1, port2} = new MessageChannel();
 
   const iframe = document.createElement('iframe');
-  iframe.setAttribute('sandbox', 'allow-scripts');
   iframe.setAttribute('style', 'display:none;');
   iframe.addEventListener('load', () => {
     port1.start();


### PR DESCRIPTION
I found that removing this line fixed `importScripts` erroring out when importing the sandbox script in the iframe `Worker`, both in Chrome and Safari.

@atesgoral do you still have that app that shows the credential behaviour of the various worker/ iframe combinations? I forget if you actually had this kind of example but if you do, I'd love to use that to check that this approach still treats requests anonymously.